### PR TITLE
Changed to storing user uploaded images into google cloud storage due…

### DIFF
--- a/app/addProperty/page.jsx
+++ b/app/addProperty/page.jsx
@@ -65,6 +65,7 @@ const AddProperty = () => {
                 body: formData,
             });
             console.log(res)
+            console.log(propertyImage.name)
             
             if (res.ok) {
                 location.assign('/dashboard')


### PR DESCRIPTION
… to the fact that the images folder in repo would keep replacing user uploaded images with the empty folder each time any changes were pushed to github. By using google cloud, the user uploaded images will not be lost